### PR TITLE
Assign local variable 'os' before referencing

### DIFF
--- a/credcrack.py
+++ b/credcrack.py
@@ -123,6 +123,7 @@ def enum_shares(q, username, password, domain):
     try:
         while True:
             with lock:
+		os = ""
                 shares, endshares = [], []
                 rhost = q.get()
 


### PR DESCRIPTION
This patch is for an error in enum_shares: "local variable 'os' referenced before assignment."